### PR TITLE
Revision 9: Remove currency

### DIFF
--- a/design.dbml
+++ b/design.dbml
@@ -54,7 +54,6 @@ Table SpaceFacilitiesRentalFeeRate {
   facility_id int [pk, ref: > SpaceFacilities.id]
   rate_code varchar [pk, ref: > RentalRateType.code]
   rate decimal [not null]
-  currency varchar [not null]
 }
 
 // Rental Rates (separated into different tables like facility)
@@ -68,7 +67,6 @@ Table SpaceRentalFeeRate {
   space_id int [pk, ref: > Space.id]
   rate_code varchar [pk, ref: > RentalRateType.code]
   rate decimal [not null]
-  currency varchar [not null]
 }
 
 // Bookings (added a surrogate key)


### PR DESCRIPTION
Let's just assume that the currency is stored as USD, since
- There is a chance that with currency field, there are multiple currency for the same space or facilities
- Revenue calculation is also trickier due to currency conversion
- Multiple currency is not required in the requirement. So this way should be simpler